### PR TITLE
Update Ruby 2.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.6.3
 
 ENV LANG C.UTF-8
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.1'
+ruby '2.6.3'
 
 gem 'rails', '~> 6.0.0.rc1'
 gem 'pg', '>= 0.18', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ DEPENDENCIES
   webdrivers
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.6.3p62
 
 BUNDLED WITH
-   1.16.6
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ http://localhost:3000 にアクセス
 ## 技術スタック
 * Docker
 * docker-compose
-* ruby:2.5.1
+* ruby:2.6.3
 * Rails 6.0.0 rc1
 * postgresql:10
 * redis:4


### PR DESCRIPTION
https://www.ruby-lang.org/ja/news/2019/04/17/ruby-2-6-3-released/